### PR TITLE
No alloc

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -1,0 +1,44 @@
+#![feature(test)]
+
+extern crate test;
+extern crate uuid;
+extern crate uuid_to_pokemon;
+
+use test::{Bencher, black_box};
+use std::fmt::Write;
+use uuid::Uuid;
+use uuid_to_pokemon::uuid_to_pokemon;
+
+#[bench]
+fn bench_eq(b: &mut Bencher) {
+    let u = Uuid::nil();
+    b.iter(|| {
+        for _ in 0..100 {
+            black_box(uuid_to_pokemon(u) == "Busy bulbasaur");
+            black_box("Busy bulbasaur" == uuid_to_pokemon(u));
+        }
+    });
+}
+
+#[bench]
+fn bench_eq_rand(b: &mut Bencher) {
+    b.iter(|| {
+        let u = Uuid::new_v4();
+        for _ in 0..100 {
+            black_box(uuid_to_pokemon(u) == "Busy bulbasaur");
+            black_box("Busy bulbasaur" == uuid_to_pokemon(u));
+        }
+    });
+}
+
+#[bench]
+fn bench_write(b: &mut Bencher) {
+    b.iter(|| {
+        let mut s = String::new();
+        let u = Uuid::new_v4();
+        for _ in 0..100 {
+            let _ = write!(s, "{}", uuid_to_pokemon(u));
+        }
+        s
+    });
+}

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -7,15 +7,15 @@ extern crate uuid_to_pokemon;
 use test::{Bencher, black_box};
 use std::fmt::Write;
 use uuid::Uuid;
-use uuid_to_pokemon::uuid_to_pokemon;
+use uuid_to_pokemon::{uuid_to_pokemon, PokemonUuid};
 
 #[bench]
 fn bench_eq(b: &mut Bencher) {
     let u = Uuid::nil();
     b.iter(|| {
         for _ in 0..100 {
-            black_box(uuid_to_pokemon(u) == "Busy bulbasaur");
-            black_box("Busy bulbasaur" == uuid_to_pokemon(u));
+            black_box(uuid_to_pokemon(u) == PokemonUuid::parse_str("Busy bulbasaur").unwrap());
+            black_box(PokemonUuid::parse_str("Busy bulbasaur").unwrap() == uuid_to_pokemon(u));
         }
     });
 }
@@ -25,8 +25,8 @@ fn bench_eq_rand(b: &mut Bencher) {
     b.iter(|| {
         let u = Uuid::new_v4();
         for _ in 0..100 {
-            black_box(uuid_to_pokemon(u) == "Busy bulbasaur");
-            black_box("Busy bulbasaur" == uuid_to_pokemon(u));
+            black_box(uuid_to_pokemon(u) == PokemonUuid::parse_str("Busy bulbasaur").unwrap());
+            black_box(PokemonUuid::parse_str("Busy bulbasaur").unwrap() == uuid_to_pokemon(u));
         }
     });
 }


### PR DESCRIPTION
Return a simple view instead of allocating a new string. It's a (partially) breaking change as the return type changes.

before:
```
test bench_gen_and_eq ... bench:          93 ns/iter (+/- 2)
test bench_write      ... bench:      11,200 ns/iter (+/- 396)
```

after:
```
test bench_gen_and_eq ... bench:          45 ns/iter (+/- 5)
test bench_write      ... bench:       5,018 ns/iter (+/- 166)
```